### PR TITLE
Fix: Remove erroneous /error route

### DIFF
--- a/todo-app/main.py
+++ b/todo-app/main.py
@@ -129,9 +129,6 @@ async def delete_todo(todo_id: str):
     del todos_db[todo_id]
     return
 
-@app.get("/error")
-async def raise_error(msg: str = Query(..., description="Error message to raise")):
-    raise Exception(msg)
 
 if __name__ == "__main__":
     import uvicorn


### PR DESCRIPTION
Resolves a runtime error caused by the /error route by removing the route and the associated raise_error function as indicated in the provided error log.